### PR TITLE
Check runtime errors when clearing data

### DIFF
--- a/background.js
+++ b/background.js
@@ -50,6 +50,10 @@ function clearAllBrowserData() {
     "serviceWorkers": true,
     "webSQL": true
   }, () => {
+    if (chrome.runtime.lastError) {
+      console.error('Fehler beim Löschen der Browserdaten:', chrome.runtime.lastError);
+      return;
+    }
     console.log('Browserdaten wurden gelöscht');
     
     // Aktualisiere die Zeit der letzten Löschung


### PR DESCRIPTION
## Summary
- handle errors from `chrome.browsingData.remove` in `clearAllBrowserData`

## Testing
- `node -c background.js`
- `node -c popup.js`


------
https://chatgpt.com/codex/tasks/task_e_6887dcf573e483288eaffcab7fc22831