### PR TITLE
Unify FOUR_DAYS_MS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   Works out of the box—no settings required.  
 
 - **Customizable**
-  Easily tweak which data types to clear and the time range in `background.js`.
+  Easily tweak which data types to clear and the cleanup interval in `background.js`.
 - **Security First**
   Built with a strict Content Security Policy to block remote code execution.
 - **Friendly Status**
@@ -68,7 +68,10 @@ To adjust what gets cleared or change the time window:
 
 1. Open `background.js`.
 
-2. Locate the `chrome.browsingData.remove` call:
+2. Modify the `FOUR_DAYS_MS` constant near the top to change how often
+   automatic cleanup runs. The value is in milliseconds (default is four days).
+
+3. Locate the `chrome.browsingData.remove` call:
 
    ```javascript
   chrome.browsingData.remove(
@@ -87,7 +90,7 @@ To adjust what gets cleared or change the time window:
 
 - Toggle any data type by setting its boolean to `false`.
 
-3. Save your changes and reload the extension at `chrome://extensions`.
+4. Save your changes and reload the extension at `chrome://extensions`.
 
 ---
 

--- a/background.js
+++ b/background.js
@@ -1,9 +1,9 @@
 "use strict";
 
 // Konstanten für die Zeitabstände
-const VIER_TAGE_IN_MINUTEN = 4 * 24 * 60; // 5760 Minuten
+const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
+const FOUR_DAYS_MINUTES = FOUR_DAYS_MS / (60 * 1000);
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
-const FOUR_DAYS_MS = VIER_TAGE_IN_MINUTEN * 60 * 1000;
 
 // Beim Installieren der Extension
 chrome.runtime.onInstalled.addListener(() => {
@@ -11,8 +11,8 @@ chrome.runtime.onInstalled.addListener(() => {
   
   // Erstelle einen wiederkehrenden Alarm
   chrome.alarms.create('clearBrowserData', {
-    periodInMinutes: VIER_TAGE_IN_MINUTEN,
-    delayInMinutes: VIER_TAGE_IN_MINUTEN
+    periodInMinutes: FOUR_DAYS_MINUTES,
+    delayInMinutes: FOUR_DAYS_MINUTES
   });
   
   // Speichere den Installationszeitpunkt


### PR DESCRIPTION
## Summary
- remove unused `VIER_TAGE_IN_MINUTEN` constant
- expose `FOUR_DAYS_MS` and derive minutes from it for the alarm
- document how to change the cleanup interval in `README`

## Testing
- `node --check background.js && node --check popup.js`

------
https://chatgpt.com/codex/tasks/task_e_68885776d42c83289f29c32e4e3ad29d