### PR TITLE
Resolve merge leftovers and clean scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
   Works out of the box—no settings required.  
 
 - **Customizable**
-  Easily tweak which data types to clear and the time range via `constants.js` and `background.js`.
-=======
-  Easily tweak which data types to clear and the cleanup interval in `background.js`.
+  Easily tweak which data types to clear and adjust the cleanup interval in `background.js` and `constants.js`.
 - **Security First**
   Built with a strict Content Security Policy to block remote code execution.
 - **Friendly Status**
@@ -70,32 +68,6 @@ To adjust what gets cleared or change the time window:
 
 1. Open `constants.js` to modify the cleaning interval.
 2. Open `background.js` to change the data types being removed.
-=======
-1. Open `background.js`.
-
-2. Modify the `FOUR_DAYS_MS` constant near the top to change how often
-   automatic cleanup runs. The value is in milliseconds (default is four days).
-
-3. Locate the `chrome.browsingData.remove` call:
-
-   ```javascript
-  chrome.browsingData.remove(
-    { since: lastCleanTime || Date.now() - 365*24*60*60*1000 }, // since last clean or max 1 year
-     {
-       history:   true,
-       cache:     true,
-       cookies:   true,
-       downloads: true
-     }
-   );
-   ```
-
-- `since`: timestamp in milliseconds
-  *(e.g. `Date.now() - 24*60*60*1000` for the last 24 hours; default is the last run or one year)*
-
-- Toggle any data type by setting its boolean to `false`.
-
-4. Save your changes and reload the extension at `chrome://extensions`.
 
 ---
 

--- a/background.js
+++ b/background.js
@@ -1,28 +1,19 @@
 "use strict";
 
-// Konstanten für die Zeitabstände
-const VIER_TAGE_IN_MINUTEN = 4 * 24 * 60; // 5760 Minuten
-const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
-const FOUR_DAYS_MS = VIER_TAGE_IN_MINUTEN * 60 * 1000;
+// Load shared constants
+importScripts('constants.js');
 
-// Einfache konfigurierbare Logging-Funktion
+// Derived time constants
+const FOUR_DAYS_MINUTES = FOUR_DAYS_MS / (60 * 1000);
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+// Simple configurable logging function
 const DEBUG_LOGGING = false;
 const log = (...args) => {
   if (DEBUG_LOGGING) {
     console.debug(...args);
   }
 };
-
-"use strict";
-
-// Shared constants
-importScripts('constants.js');
-
-// Konstanten für die Zeitabstände
-const VIER_TAGE_IN_MINUTEN = FOUR_DAYS_MS / (60 * 1000); // 5760 Minuten
-const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
-const FOUR_DAYS_MINUTES = FOUR_DAYS_MS / (60 * 1000);
-const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 // Beim Installieren der Extension
 chrome.runtime.onInstalled.addListener(() => {
@@ -74,13 +65,6 @@ chrome.runtime.onStartup.addListener(() => {
 });
 
 // Wenn der Alarm ausgelöst wird
-chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === 'clearBrowserData') {
-    clearAllBrowserData().catch((err) => {
-      console.error('Fehler beim periodischen Löschen:', err);
-    });
-  }
-});
 
 // Funktion zum Löschen der Browserdaten
 async function clearAllBrowserData() {
@@ -143,68 +127,7 @@ async function clearAllBrowserData() {
       }
     );
   });
-}
-=======
-async function clearAllBrowserData() {
-  const defaultSince = Date.now() - ONE_YEAR_MS;
-  const { lastCleanTime = 0, cleanCount = 0 } = await new Promise((resolve) => {
-    chrome.storage.local.get(['lastCleanTime', 'cleanCount'], (result) => {
-      if (chrome.runtime.lastError) {
-        console.error('Fehler beim Lesen von lastCleanTime/cleanCount:', chrome.runtime.lastError);
-        resolve({ lastCleanTime: 0, cleanCount: 0 });
-        return;
-      }
-      resolve(result);
-    });
-  });
 
-  const since = Math.max(lastCleanTime, defaultSince);
-
-  await new Promise((resolve, reject) => {
-    chrome.browsingData.remove(
-      { since },
-      {
-        appcache: true,
-        cache: true,
-        cacheStorage: true,
-        cookies: true,
-        downloads: false, // Downloads behalten
-        fileSystems: true,
-        formData: true,
-        history: true,
-        indexedDB: true,
-        localStorage: true,
-        passwords: false, // Passwörter behalten
-        serviceWorkers: true,
-        webSQL: true
-      },
-      () => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-          return;
-        }
-        resolve();
-      }
-    );
-  });
-
-  console.log('Browserdaten wurden gelöscht');
-
-  await new Promise((resolve, reject) => {
-    chrome.storage.local.set(
-      {
-        lastCleanTime: Date.now(),
-        cleanCount: cleanCount + 1
-      },
-      () => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-          return;
-        }
-        resolve();
-      }
-    );
-  });
 }
 
 // Manuelles Löschen über Nachricht vom Popup


### PR DESCRIPTION
## Summary
- remove merge conflict markers from README and background script
- consolidate constants and logging in `background.js`
- drop duplicate alarm handler and cleanup function

## Testing
- `node -c background.js`
- `node -e "const fs=require('fs');fs.readFileSync('README.md','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_68885a00dc74832884c39234f4eaef0e