### PR TITLE
Refactor constant usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@
 
 To adjust what gets cleared or change the time window:
 
-1. Open `constants.js` to modify the cleaning interval.
+1. Open `constants.js` to modify the cleaning interval. The constants are shared
+   between the background script and popup, so changes apply everywhere.
 2. Open `background.js` to change the data types being removed.
 
 ---

--- a/constants.js
+++ b/constants.js
@@ -1,4 +1,5 @@
 "use strict";
 
-// Shared time interval for automatic cleaning (4 days)
+// Global constants shared across extension scripts
+// Interval for automatic cleaning (4 days)
 const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;

--- a/popup.js
+++ b/popup.js
@@ -7,7 +7,7 @@ const cleanCountEl = document.getElementById('cleanCount');
 const cleanNowBtn = document.getElementById('cleanNowBtn');
 const successMessage = document.getElementById('successMessage');
 const errorMessage = document.getElementById('errorMessage');
-const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
+// FOUR_DAYS_MS is defined in constants.js and available globally
 
 // Status beim Laden abrufen
 updateStatus();


### PR DESCRIPTION
## Summary
- use shared constant from `constants.js` inside `popup.js`
- document constant sharing in `README`
- clarify that `constants.js` is used across scripts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68885a00dc74832884c39234f4eaef0e